### PR TITLE
Add Support for more API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spreedly
 
-A wrapper of the Spreedly API.
+A wrapper of the Spreedly API. This library is not officially supported.
 
 ## Installation
 

--- a/lib/spreedly/environment.ex
+++ b/lib/spreedly/environment.ex
@@ -24,8 +24,38 @@ defmodule Spreedly.Environment do
     |> response
   end
 
+  def retain_payment_method(env, token) do
+    HTTPoison.put(retain_payment_method_url(token), empty_body, headers(env))
+    |> response
+  end
+
+  def redact_payment_method(env, token) do
+    HTTPoison.put(redact_payment_method_url(token), empty_body, headers(env))
+    |> response
+  end
+
   def purchase(env, gateway_token, payment_method_token, amount, currency_code \\ "USD", options \\ []) do
-    HTTPoison.post(purchase_url(gateway_token), purchase_body(payment_method_token, amount, currency_code, options), headers(env))
+    HTTPoison.post(purchase_url(gateway_token), auth_or_purchase_body(payment_method_token, amount, currency_code, options), headers(env))
+    |> response
+  end
+
+  def authorization(env, gateway_token, payment_method_token, amount, currency_code \\ "USD", options \\ []) do
+    HTTPoison.post(authorization_url(gateway_token), auth_or_purchase_body(payment_method_token, amount, currency_code, options), headers(env))
+    |> response
+  end
+
+  def capture(env, transaction_token) do
+    HTTPoison.post(capture_url(transaction_token), empty_body, headers(env))
+    |> response
+  end
+
+  def void(env, transaction_token) do
+    HTTPoison.post(void_url(transaction_token), empty_body, headers(env))
+    |> response
+  end
+
+  def credit(env, transaction_token) do
+    HTTPoison.post(credit_url(transaction_token), empty_body, headers(env))
     |> response
   end
 

--- a/lib/spreedly/request_body.ex
+++ b/lib/spreedly/request_body.ex
@@ -28,7 +28,7 @@ defmodule Spreedly.RequestBody do
     |> Poison.encode!
   end
 
-  def purchase_body(payment_method_token, amount, currency_code, options) do
+  def auth_or_purchase_body(payment_method_token, amount, currency_code, options) do
     %{
       transaction:
       %{
@@ -48,6 +48,11 @@ defmodule Spreedly.RequestBody do
         currency_code: currency_code,
       } |> Map.merge(Map.new(options))
     }
+    |> Poison.encode!
+  end
+
+  def empty_body do
+    %{}
     |> Poison.encode!
   end
 

--- a/lib/spreedly/url.ex
+++ b/lib/spreedly/url.ex
@@ -8,12 +8,28 @@ defmodule Spreedly.URL do
     "#{base_url}/receivers.json"
   end
 
+  def authorization_url(gateway_token) do
+    "#{base_url}/gateways/#{gateway_token}/authorize.json"
+  end
+
   def purchase_url(gateway_token) do
     "#{base_url}/gateways/#{gateway_token}/purchase.json"
   end
 
   def verify_url(gateway_token) do
     "#{base_url}/gateways/#{gateway_token}/verify.json"
+  end
+
+  def capture_url(transaction_token) do
+    "#{base_url}/transactions/#{transaction_token}/capture.json"
+  end
+
+  def void_url(transaction_token) do
+    "#{base_url}/transactions/#{transaction_token}/void.json"
+  end
+
+  def credit_url(transaction_token) do
+    "#{base_url}/transactions/#{transaction_token}/credit.json"
   end
 
   def show_gateway_url(token) do
@@ -40,6 +56,15 @@ defmodule Spreedly.URL do
     "#{base_url}/payment_methods.json"
   end
 
+  def retain_payment_method_url(token) do
+    "#{base_url}/payment_methods/#{token}/retain.json"
+  end
+
+  def redact_payment_method_url(token) do
+    "#{base_url}/payment_methods/#{token}/redact.json"
+  end
+
+
   def list_payment_method_transactions_url(token, options) do
     encoded = URI.encode_query(options)
     "#{base_url}/payment_methods/#{token}/transactions.json#{params(encoded)}"
@@ -56,7 +81,7 @@ defmodule Spreedly.URL do
   end
 
   defp base_url do
-    "https://core.spreedly.com/v1"
+    Application.get_env(:spreedly, :base_url, "https://core.spreedly.com/v1")
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,10 +31,8 @@ defmodule Spreedly.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:httpoison, "~> 0.9.0"},
-      {:hackney, "1.6.1"},
-      {:poison, "~> 2.0 or ~> 3.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:httpoison, "~> 0.10.0"},
+      {:poison, "~> 2.0 or ~> 3.0"}
     ]
   end
 
@@ -51,7 +49,7 @@ defmodule Spreedly.Mixfile do
     [
       maintainers: ["Duff O'Melia <duff@omelia.org>"],
       licenses:    ["MIT"],
-      links:       %{"GitHub" => "https://github.com/duff/spreedly-elixir"}
+      links:       %{"GitHub" => "https://github.com/spreedly/spreedly-elixir"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,8 @@
-%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
-  "httpoison": {:hex, :httpoison, "0.9.2", "a211a8e87403a043c41218e64df250d321f236ac57f786c6a0ccf3e9e817c819", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
+%{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+  "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
+  "httpoison": {:hex, :httpoison, "0.10.0", "4727b3a5e57e9a4ff168a3c2883e20f1208103a41bccc4754f15a9366f49b676", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}

--- a/test/remote/authorization_remote_test.exs
+++ b/test/remote/authorization_remote_test.exs
@@ -1,0 +1,42 @@
+defmodule Remote.AuthorizationTest do
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, reason } = Environment.authorization(bogus_env, "gateway_token", "payment_method_token", 100)
+    assert reason =~ "Unable to authenticate"
+  end
+
+  test "payment method not found" do
+    { :error, reason } = Environment.authorization(env, create_test_gateway.token, "unknown_card", 100)
+    assert reason =~ "There is no payment method"
+  end
+
+  test "gateway not found" do
+    { :error, reason } = Environment.authorization(env, "unknown_gateway", create_test_card.token, 100)
+    assert reason == "Unable to find the specified gateway."
+  end
+
+  test "successful authorization" do
+    {:ok, trans } = Environment.authorization(env, create_test_gateway.token, create_test_card.token, 100)
+    assert trans.succeeded == true
+    assert trans.payment_method.last_name == "Cauthon"
+    assert trans.transaction_type == "Authorization"
+  end
+
+  test "successful authorization with options" do
+    {:ok, trans } = Environment.authorization(env, create_test_gateway.token, create_test_card.token, 100, "GBP", order_id: "44", description: "Wow")
+    assert trans.succeeded == true
+    assert trans.description == "Wow"
+    assert trans.order_id == "44"
+    assert trans.currency_code == "GBP"
+  end
+
+  test "failed authorization" do
+    {:ok, trans } = Environment.authorization(env, create_test_gateway.token, create_declined_test_card.token, 100)
+    assert trans.succeeded == false
+    assert trans.state == "gateway_processing_failed"
+    assert trans.message == "Unable to process the authorize transaction."
+  end
+
+end

--- a/test/remote/capture_test.exs
+++ b/test/remote/capture_test.exs
@@ -1,0 +1,21 @@
+defmodule Remote.CaptureTest do
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, reason } = Environment.capture(bogus_env, "gateway_token")
+    assert reason =~ "Unable to authenticate"
+  end
+
+  test "transaction method not found" do
+    { :error, reason } = Environment.capture(env, "no_transaction_token")
+    assert reason =~ "Unable to find the specified reference transaction."
+  end
+
+  test "successful capture" do
+    {:ok, trans } = Environment.capture(env, create_auth_transaction.token)
+    assert trans.succeeded == true
+    assert trans.transaction_type == "Capture"
+  end
+
+end

--- a/test/remote/credit.ex
+++ b/test/remote/credit.ex
@@ -1,0 +1,21 @@
+defmodule Remote.CreditTest do
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, reason } = Environment.void(bogus_env, "gateway_token")
+    assert reason =~ "Unable to authenticate"
+  end
+
+  test "transaction method not found" do
+    { :error, reason } = Environment.credit(env, "no_transaction_token")
+    assert reason =~ "Unable to find the specified reference transaction."
+  end
+
+  test "successful void" do
+    {:ok, trans } = Environment.credit(env, create_purchase_transaction.token)
+    assert trans.succeeded == true
+    assert trans.transaction_type == "Credit"
+  end
+
+end

--- a/test/remote/redact_payment_method_test.exs
+++ b/test/remote/redact_payment_method_test.exs
@@ -1,0 +1,23 @@
+defmodule Remote.RedactPaymentMethodTest do
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, message } = Environment.redact_payment_method(bogus_env, "some_card_token")
+    assert message =~ "Unable to authenticate"
+  end
+
+  test "non existent" do
+    { :error, reason } = Environment.redact_payment_method(env, "non_existent_card")
+    assert reason =~ "Unable to find the specified payment method."
+  end
+
+  test "successfully redact" do
+    {:ok, add_trans } = Environment.add_credit_card(env, card_deets(retained: true))
+    assert add_trans.payment_method.storage_state == "retained"
+    {:ok, redact_trans} = Environment.redact_payment_method(env, add_trans.payment_method.token)
+    assert redact_trans.payment_method.storage_state == "redacted"
+    assert redact_trans.transaction_type == "RedactPaymentMethod"
+  end
+
+end

--- a/test/remote/retain_payment_method_test.exs
+++ b/test/remote/retain_payment_method_test.exs
@@ -1,0 +1,23 @@
+defmodule Remote.RetainPaymentMethodTest do
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, message } = Environment.retain_payment_method(bogus_env, "some_card_token")
+    assert message =~ "Unable to authenticate"
+  end
+
+  test "non existent" do
+    { :error, reason } = Environment.retain_payment_method(env, "non_existent_card")
+    assert reason =~ "Unable to find the specified payment method."
+  end
+
+  test "successfully retain" do
+    {:ok, add_trans } = Environment.add_credit_card(env, card_deets)
+    assert add_trans.payment_method.storage_state == "cached"
+    {:ok, retain_trans} = Environment.retain_payment_method(env, add_trans.payment_method.token)
+    assert retain_trans.payment_method.storage_state == "retained"
+    assert retain_trans.transaction_type == "RetainPaymentMethod"
+  end
+
+end

--- a/test/remote/verification_test.exs
+++ b/test/remote/verification_test.exs
@@ -35,7 +35,7 @@ defmodule Remote.VerificationTest do
     assert trans.currency_code == "GBP"
   end
 
-  test "successful purchase with options" do
+  test "successful verify with options" do
     {:ok, trans } = Environment.verify(env, create_test_gateway.token, create_test_card.token, "GBP", order_id: "44", description: "Wow")
     assert trans.succeeded == true
     assert trans.description == "Wow"

--- a/test/remote/void_test.exs
+++ b/test/remote/void_test.exs
@@ -1,0 +1,21 @@
+defmodule Remote.VoidTest do
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, reason } = Environment.void(bogus_env, "gateway_token")
+    assert reason =~ "Unable to authenticate"
+  end
+
+  test "transaction method not found" do
+    { :error, reason } = Environment.void(env, "no_transaction_token")
+    assert reason =~ "Unable to find the specified reference transaction."
+  end
+
+  test "successful void" do
+    {:ok, trans } = Environment.void(env, create_purchase_transaction.token)
+    assert trans.succeeded == true
+    assert trans.transaction_type == "Void"
+  end
+
+end

--- a/test/support/remote/environment_case.ex
+++ b/test/support/remote/environment_case.ex
@@ -43,6 +43,16 @@ defmodule Remote.Environment.Case do
         trans
       end
 
+      defp create_purchase_transaction do
+        {:ok, trans } = Environment.purchase(env, create_test_gateway.token, create_test_card.token, 100)
+        trans
+      end
+
+      defp create_auth_transaction do
+        {:ok, trans } = Environment.authorization(env, create_test_gateway.token, create_test_card.token, 100)
+        trans
+      end
+
     end
   end
 


### PR DESCRIPTION
This commit adds support for auth, capture, purchase, redact, retain, void and
credit.

Update package info to reference the proper github spreedly url.
Update deps - remove unused dependencies.

@duff @spreedly/product-dev 