### PR TITLE
Fix add_gateway to take a map of params

### DIFF
--- a/lib/spreedly.ex
+++ b/lib/spreedly.ex
@@ -44,9 +44,9 @@ defmodule Spreedly do
 
   alias Spreedly.Environment
 
-  @spec add_gateway(Environment.t, String.t) :: {:ok, any} | {:error, any}
-  def add_gateway(env, gateway_type) do
-    post_request(env, add_gateway_path(), add_gateway_body(gateway_type))
+  @spec add_gateway(Environment.t, String.t, map()) :: {:ok, any} | {:error, any}
+  def add_gateway(env, gateway_type, gateway_params \\ %{}) do
+    post_request(env, add_gateway_path(), add_gateway_body(gateway_type, gateway_params))
   end
 
   @spec add_receiver(Environment.t, String.t, Keyword.t) :: {:ok, any} | {:error, any}

--- a/lib/spreedly/request_body.ex
+++ b/lib/spreedly/request_body.ex
@@ -1,12 +1,12 @@
 defmodule Spreedly.RequestBody do
   @moduledoc false
 
-  def add_gateway_body(gateway_type) do
+  def add_gateway_body(gateway_type, gateway_params) do
     %{
-      gateway:
-      %{
-        gateway_type: gateway_type
-      }
+      gateway: Map.merge(
+        %{gateway_type: gateway_type},
+        gateway_params
+      )
     }
     |> Poison.encode!
   end


### PR DESCRIPTION
Hiya! We're using your library for an integration where our customers bring their own gateways and as such need to be able to use the `add_gateway` functionality. Unfortunately, this functionality is incomplete. I've created a patch that allows the rest of the required params to be provided while not breaking compatibility with the existing function signature.

- Spreedly's gateway API needs more than just the gateway_type to
  create a gateway, as credentials to talk to the gateway are
  necessary. Right now, we can't pass credentials so can only
  create the test gateway.
- For example, to create a Stripe gateway you need to pass
  `{ "gateway_type": "stripe", "login": "<stripe secret key>" }`
- This keeps the current API in tact but adds an optional map as a
  second param so you can e.g.
  `Spreedly.add_gateway(:stripe, %{login: "secret key"})`

Thanks for looking at this!