### PR TITLE
Add receive timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,19 @@ end
 
 Add it to your application dependency:
 
-```
+```elixir
 def application do
   [applications: [:spreedly]]
 end
+```
+
+## Configuration
+
+Spreedly Elixir has a limited number of configuration options that you can override in your project specific configuration files. The options include specifying the receive timeout.
+
+```elixir
+config :spreedly,
+  receive_timeout: value  # Defaults to 10_000 milliseconds
 ```
 
 ## Usage
@@ -86,4 +95,3 @@ iex> Spreedly.show_transaction(env, "TcsSf0hpfa3K3zW5eYdSOQmR0rs")
 iex> Spreedly.find_transaction(env, "NonExistentToken")
 {:error, "Unable to find the transaction NonExistentToken."}
 ```
-

--- a/lib/spreedly/base.ex
+++ b/lib/spreedly/base.ex
@@ -23,7 +23,7 @@ defmodule Spreedly.Base do
   @spec api_request(atom, Environment.t, String.t, any, Keyword.t, ((any) -> any)) :: {:ok, any} | {:error, any}
   defp api_request(method, env, path, body, options \\ [], response_callback \\ &process_response/1) do
     method
-    |> request(path, body, headers(env), options)
+    |> request(path, body, headers(env), [{:recv_timeout, receive_timeout()} | options])
     |> response_callback.()
   end
 
@@ -96,4 +96,7 @@ defmodule Spreedly.Base do
     Application.get_env(:spreedly, :base_url, "https://core.spreedly.com/v1")
   end
 
+  defp receive_timeout do
+    Application.get_env(:spreedly, :receive_timeout, 10_000)
+  end
 end

--- a/script/test
+++ b/script/test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+mix credo --strict
+mix dialyzer
+mix test --include remote
+
+echo -e `date +"\n\nSuccessful Full Test Suite Run at %Y-%m-%d %H:%M:%S\n"`


### PR DESCRIPTION
Allow projects to override the default receive timeout configuration
setting. The default is 5_000 milli seconds, which may not be
sufficient.

Successful Full Test Suite Run at 2018-03-01 10:16:12