### PR TITLE
Gateway Redaction

### DIFF
--- a/lib/spreedly.ex
+++ b/lib/spreedly.ex
@@ -64,6 +64,11 @@ defmodule Spreedly do
     put_request(env, retain_payment_method_path(token))
   end
 
+  @spec redact_gateway(Environment.t, String.t) :: {:ok, any} | {:error, any}
+  def redact_gateway(env, token) do
+    put_request(env, redact_gateway_method_path(token))
+  end
+
   @spec redact_payment_method(Environment.t, String.t) :: {:ok, any} | {:error, any}
   def redact_payment_method(env, token) do
     put_request(env, redact_payment_method_path(token))

--- a/lib/spreedly/path.ex
+++ b/lib/spreedly/path.ex
@@ -61,6 +61,10 @@ defmodule Spreedly.Path do
     "/payment_methods/#{token}/retain.json"
   end
 
+  def redact_gateway_method_path(token) do
+    "/gateways/#{token}/redact.json"
+  end
+
   def redact_payment_method_path(token) do
     "/payment_methods/#{token}/redact.json"
   end

--- a/test/remote/redact_gateway_test.exs
+++ b/test/remote/redact_gateway_test.exs
@@ -1,0 +1,24 @@
+defmodule Remote.RedactGatewayMethodTest do
+  use Remote.Environment.Case
+
+  test "invalid credentials" do
+    bogus_env = Environment.new("invalid", "credentials")
+    { :error, message } = Spreedly.redact_gateway(bogus_env, "some_gateway_token")
+    assert message =~ "Unable to authenticate"
+  end
+
+  test "non existent" do
+    { :error, reason } = Spreedly.redact_gateway(env(), "non_existent_gateway")
+    assert reason =~ "Unable to find the specified gateway."
+  end
+
+  test "successfully redact" do
+    {:ok, add_gateway } = Spreedly.add_gateway(env(), :test)
+    assert  "retained" == add_gateway.state
+
+    {:ok, redact_gateway} = Spreedly.redact_gateway(env(), add_gateway.token)
+    assert "redacted" == redact_gateway.gateway.state
+    assert "RedactGateway" == redact_gateway.transaction_type
+    assert redact_gateway.token
+  end
+end


### PR DESCRIPTION
Implemented the ability to [redact gateways](https://docs.spreedly.com/reference/api/v1/gateways/redact/) via Spreedly.

This functionality was currently missing in the spreedly-elixir implementation. Unit tests have been provided with this implementation. For more information on gateway redaction please see: https://docs.spreedly.com/reference/api/v1/gateways/redact/

Example usage: `{:ok, response} = Spreedly.redact_gateway(env, gateway_token)`