### PR TITLE
Handle additional response codes and response body

### DIFF
--- a/test/remote/show_transaction_test.exs
+++ b/test/remote/show_transaction_test.exs
@@ -12,6 +12,13 @@ defmodule Remote.ShowTransactionTest do
     assert reason =~ "Unable to find the transaction"
   end
 
+  test "invalid token" do
+    { :error, reason } = Spreedly.show_transaction(env(), "http://subdomain.spreedly.test")
+
+    assert reason =~ "<html>"
+    assert reason =~ "<title>The page you were looking for doesn't exist (404)</title>"
+  end
+
   test "show verify transaction" do
     {:ok, trans } = Spreedly.show_transaction(env(), create_verify_transaction().token)
     assert trans.payment_method.last_name == "Cauthon"


### PR DESCRIPTION
Update the library to handle error responses that do not include a JSON
response body.

Add support for handling response code 429 Too many requests which is
returned if limiting is exceeded.

Add support for handling response code 408 Request timeout which is
returned if a downstream service (third party gateway) does not respond
in a timely fashion.

Successful Full Test Suite Run at 2018-05-03 16:44:14