### PR TITLE
Upgrade credo to version 0.9

### DIFF
--- a/lib/spreedly/base.ex
+++ b/lib/spreedly/base.ex
@@ -2,7 +2,7 @@ defmodule Spreedly.Base do
   @moduledoc false
   use HTTPoison.Base
 
-  alias HTTPoison.{Response, AsyncResponse, Error}
+  alias HTTPoison.{AsyncResponse, Error, Response}
   alias Spreedly.Environment
 
   @spec get_request(Environment.t, String.t, Keyword.t, ((any) -> any)) :: {:ok, any} | {:error, any}

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Spreedly.Mixfile do
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:poison, "~> 2.0 or ~> 3.0"},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-      {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
+      {:credo, "~> 0.9", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.7", "b1aad9cd3aa7acdbaea49765bfc9f1605dc4555023a037dc9ea7a70539615bc8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This upgrades the version of credo to 0.9 in order to support elixir 1.6

A small re-ordering change has been made to base.ex in accordance with a
recommendation made by credo.

ENCEG-1981 #close

Successful Full Test Suite Run at 2018-06-14 14:16:11