### PR TITLE
Add list-supported-gateways API wrapper

### DIFF
--- a/lib/spreedly.ex
+++ b/lib/spreedly.ex
@@ -245,6 +245,14 @@ defmodule Spreedly do
     get_request(env, list_created_gateways_path(), params)
   end
 
+  @doc """
+  Retrieve a list of all gateways, and their properties, supported by Spreedly. 
+  
+  """
+  def list_supported_gateways do
+    get_request(nil, list_supported_gateways_path())
+  end
+
   defp transcript_response({:error, %HTTPoison.Error{reason: reason}}), do: {:error, reason}
   defp transcript_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
     {:ok, body}

--- a/lib/spreedly/base.ex
+++ b/lib/spreedly/base.ex
@@ -5,7 +5,7 @@ defmodule Spreedly.Base do
   alias HTTPoison.{AsyncResponse, Error, Response}
   alias Spreedly.Environment
 
-  @spec get_request(Environment.t, String.t, Keyword.t, ((any) -> any)) :: {:ok, any} | {:error, any}
+  @spec get_request(Environment.t | nil, String.t, Keyword.t, ((any) -> any)) :: {:ok, any} | {:error, any}
   def get_request(env, path, params \\ [], response_callback \\ &process_response/1) do
     api_request(:get, env, path, "", [params: params], response_callback)
   end
@@ -20,7 +20,7 @@ defmodule Spreedly.Base do
     api_request(:put, env, path, body)
   end
 
-  @spec api_request(atom, Environment.t, String.t, any, Keyword.t, ((any) -> any)) :: {:ok, any} | {:error, any}
+  @spec api_request(atom, Environment.t | nil, String.t, any, Keyword.t, ((any) -> any)) :: {:ok, any} | {:error, any}
   defp api_request(method, env, path, body, options \\ [], response_callback \\ &process_response/1) do
     method
     |> request(path, body, headers(env), [{:recv_timeout, receive_timeout()} | options])
@@ -99,13 +99,16 @@ defmodule Spreedly.Base do
   end
 
   @spec headers(Environment.t) :: headers
+  defp headers(nil), do: [content_type()]
   defp headers(env) do
     encoded = Base.encode64("#{env.environment_key}:#{env.access_secret}")
     [
       {"Authorization", "Basic #{encoded}"},
-      {"Content-Type", "application/json"}
+      content_type()
     ]
   end
+
+  defp content_type, do: {"Content-Type", "application/json"}
 
   defp base_url do
     Application.get_env(:spreedly, :base_url, "https://core.spreedly.com/v1")

--- a/lib/spreedly/path.ex
+++ b/lib/spreedly/path.ex
@@ -89,4 +89,8 @@ defmodule Spreedly.Path do
     "/gateways.json"
   end
 
+  def list_supported_gateways_path do
+    "/gateways_options.json"
+  end
+
 end

--- a/test/remote/list_supported_gateways_test.exs
+++ b/test/remote/list_supported_gateways_test.exs
@@ -1,0 +1,10 @@
+defmodule Remote.ListSupportedGatewaysTest do
+	use Remote.Environment.Case
+
+  	test "list supported gateways" do
+  		{:ok, response} = Spreedly.list_supported_gateways
+
+  		assert response
+  	end
+
+end


### PR DESCRIPTION
Now the library supports the list-supported-gateways API.

Since this API does not require authentication, the specs for the
get_request and api_request method have been modified to accept nil in
place of an environment.

ENCEG-1984 #close

Successful Full Test Suite Run at 2018-06-19 12:03:15