### PR TITLE
Handle 5xx responses Spreedly Core

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spreedly.Mixfile do
   def project do
     [
       app: :spreedly,
-      version: "2.1.0",
+      version: "2.1.1",
       elixir: "~> 1.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Update response processing to handle 5xx responses by returning an
{:error, reason} tuple.

[ENCEG-2362](https://spreedly.atlassian.net/browse/ENCEG-2362)