### PR TITLE
Remove credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 /doc
 .tool-versions*
 /.elixir_ls
+config/test.secret.exs

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ iex> Spreedly.find_transaction(env, "NonExistentToken")
 
 We're happy to consider [pull requests](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
-To help ensure a consistent code style and passing tests, we ask that you execute `script/test` before submitting the PR. The test script runs Credo, Dialyzer and the remote test suite.
+To help ensure a consistent code style and passing tests, we ask that you execute `script/test` before submitting the PR. The test script runs Credo, Dialyzer and the remote test suite. To run the remote test suite, the `config/test.secret.exs` file must have valid Spreedly credentials.
 
 Upon success, it will output a message like:
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,15 @@
 use Mix.Config
 
-config :spreedly,
-  environment_key: "R7lHscqcYkZeDGGbthKp6GKMu15",
-  access_secret: "8sefxO5Q44sLWpmZpalQS3Qlqo03JbCemsqsWJR3YOLCuigOFRlaLSAn0WaL5dWU"
+if File.exists?("#{__DIR__}/test.secret.exs") do
+  import_config "test.secret.exs"
+else
+  Mix.shell().info([:yellow, "\nExpected a config/test.secret.exs file to exist."])
+
+  msg = """
+  We use this file to specify gitignored configuration information
+  used to run remote tests.
+  See the top-level README.md for instructions.
+  """
+
+  Mix.shell().info([:yellow, msg])
+end

--- a/lib/spreedly/base.ex
+++ b/lib/spreedly/base.ex
@@ -74,7 +74,8 @@ defmodule Spreedly.Base do
   defp reason_phrase(status_code) do
     statuses = %{
       408 => "Request Timeout See https://docs.spreedly.com/reference/api/v1/#408-request-timeout",
-      429 => "Too many requests, rate limit exceeded. See https://docs.spreedly.com/reference/api/v1/#429-too-many-requests",
+      429 =>
+        "Too many requests, rate limit exceeded. See https://docs.spreedly.com/reference/api/v1/#429-too-many-requests",
       500 => "Internal Server Error",
       501 => "Not Implemented",
       502 => "Bad Gateway",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spreedly.Mixfile do
   def project do
     [
       app: :spreedly,
-      version: "2.1.1",
+      version: "2.1.2",
       elixir: "~> 1.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/support/remote/environment_case.ex
+++ b/test/support/remote/environment_case.ex
@@ -8,11 +8,13 @@ defmodule Remote.Environment.Case do
       alias Spreedly
 
       defp card_deets(options \\ []) do
+        today = Date.utc_today()
+
         default_deets = [
           email: "matrim@wot.com",
           number: "5555555555554444",
-          month: 1,
-          year: 2019,
+          month: today.month,
+          year: today.year + 3,
           last_name: "Cauthon",
           first_name: "Matrim"
         ]


### PR DESCRIPTION
Instead of using hardcoded API credentials for the remote test suite,
use environment variables. This also fixes some remote tests that fail
due to an expired credit card.

Fixes #10

Successful Full Test Suite Run at 2019-05-31 09:48:37